### PR TITLE
MicroPython: Migrate to mp_obj_malloc_with_finaliser.

### DIFF
--- a/micropython/qrcode.c
+++ b/micropython/qrcode.c
@@ -16,7 +16,7 @@ mp_obj_t qrcode___del__(mp_obj_t self_in) {
 }
 
 mp_obj_t qrcode_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
-    qrcode_obj_t *self = m_new_obj_with_finaliser(qrcode_obj_t);
+    qrcode_obj_t *self = mp_obj_malloc_with_finaliser(qrcode_obj_t, &qrcode_type);
 
     enum { ARG_ecc, ARG_mask };
     static const mp_arg_t allowed_args[] = {
@@ -26,7 +26,6 @@ mp_obj_t qrcode_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    self->base.type = &qrcode_type;
     self->qr0 = m_new(uint8_t, qrcodegen_BUFFER_LEN_MAX);
     self->tempBuffer = m_new(uint8_t, qrcodegen_BUFFER_LEN_MAX);
     self->ecc = args[ARG_ecc].u_int;


### PR DESCRIPTION
This replaces calling m_new_obj_with_finaliser and explicitly setting obj->base.type.

New style added: https://github.com/micropython/micropython/commit/4133c0304011ff7be23f47516aac20ed54505e7a

Old style removed: https://github.com/micropython/micropython/commit/971617196644775905fd821c39c6a7771b63dbaf